### PR TITLE
Surface flame length correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ The model was originally developed by Phil as an MS Excel application, and
 subsequently implemented as a C++ program by Chris Thomas. 
 
 This Scala version is a port of the C++ sources.
+
+This branch was made by PZ for the ET project

--- a/fire/src/main/scala/ffm/fire/DefaultSurfaceFireAttributes.scala
+++ b/fire/src/main/scala/ffm/fire/DefaultSurfaceFireAttributes.scala
@@ -54,7 +54,7 @@ class DefaultSurfaceFireAttributes(sf: Surface) extends SurfaceFireAttributes {
   def headFlameLength(surfaceWindSpeed: Double): Double =
     if (sf.deadFuelMoistureProp >= ModelSettings.ExtinctionDFMC) 0.0
     else if (sf.fuelLoad < ModelSettings.MinFuelLoadForSurfaceHeadFire) 0.0
-    else 8.64 * headROS(surfaceWindSpeed) + 0.36 * sf.fuelLoad
+    else 8.64 * headROS(surfaceWindSpeed) + 0.036 * sf.fuelLoad
 
   /**
    * Overall surface fire rate of spread (m/s).


### PR DESCRIPTION
Corrects Burrow's surface flame length model, which multiplied the effect of the surface fuel load by a factor of 10 beyond the original equation.